### PR TITLE
Add status badge model API

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,8 +8,13 @@ from CTFd.utils.dates import ctf_ended, ctf_started
 from CTFd.utils.user import is_verified, is_admin
 from CTFd.utils.decorators import during_ctf_time_only
 from sqlalchemy.sql import and_
+from .badge import onload as badge_onload, register_routes as badge_register_routes
 
 def load(app):
+	db.create_all()
+
+	badge_onload(app)
+
 	@app.route("/OneSignalSDKWorker.js", methods=["GET"])
 	def worker():
 		filename = safe_join(app.root_path, 'themes', 'tsgctf', 'static', 'OneSignalSDKWorker.js')
@@ -91,3 +96,5 @@ def load(app):
 
 		db.session.close()
 		return {"success": True, "data": response}
+
+	badge_register_routes(app)

--- a/assets/badge.js
+++ b/assets/badge.js
@@ -1,0 +1,135 @@
+// HACK: We want to keep CTFd repository untouched as possible.
+// So we edit DOM of admin page by this script.
+// Note that this script only works on admin page,
+// therefore dirty hack would be acceptable.
+
+const submitBadge = async (challengeId, badgeUrl, method) => {
+  // HACK: Get CSRF token from global variable `init`
+  // eslint-disable-next-line no-undef
+  if (init) {
+    // eslint-disable-next-line no-undef
+    const csrf = init.csrfNonce;
+    const ep = `/api/v1/challenges/${challengeId}/badge`;
+    return await fetch(ep, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        'Csrf-Token': csrf,
+      },
+      body: JSON.stringify({
+        badge_url: badgeUrl,
+      }),
+    });
+  }
+}
+
+const getBadge = async (challengeId) => {
+  const ep = `/api/v1/challenges/${challengeId}/badge`;
+  return fetch(ep, {
+    method: "GET",
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }).then((res) => {
+    if (res.ok)
+      return res.json();
+    else
+      return null;
+  }).catch(() => {
+    return null;
+  });
+}
+
+const doAddBadgeForm = ($form, defaultValue, submitCallback) => {
+  const innerHTML = `
+  <div class="form-group" id="form-tsg-badge">
+    <label>
+      Badge URL:<br>
+      <small class="form-text text-muted">
+        Status badge endpoint. Leave empty to disable.
+      </small>
+    </label>
+    <input type="text" class="form-control" name="badge_url" value="${defaultValue}">
+  </div>
+  `;
+
+  const submitHook = async () => {
+    submitCallback();
+  };
+  $form.submit(submitHook);
+
+  $form.find('button[type="submit"]').parent().before(innerHTML)
+}
+
+const addBadgeFormEntryNew = ($form) => {
+  const challengeIdInput = $('input#challenge_id');
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach(async (mutation) => {
+      if (mutation.attributeName === 'value') {
+        const challengeId = challengeIdInput.val();
+        const badgeUrl = $form.find('input[name="badge_url"]').val();
+        if (challengeId !== '') {
+          const res = await submitBadge(challengeId, badgeUrl, "POST");
+          if (res.status !== 200) {
+            console.error(`Failed to submit badge: ${res.status}`);
+            alert(`Failed to submit badge: ${res.status}`)
+          }
+        }
+      }
+    });
+  });
+
+  doAddBadgeForm($form, '', () => {
+    observer.observe(challengeIdInput[0], { attributes: true });
+  })
+}
+
+const hookChallengeNewPage = () => {
+  const divCreateChalEntry = $('#create-chal-entry-div');
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      if (mutation.addedNodes.length > 0) {
+        for (const addedNode of mutation.addedNodes) {
+          if (addedNode.nodeName === 'FORM') {
+            addBadgeFormEntryNew($(addedNode));
+          }
+        }
+      }
+    });
+  });
+  observer.observe(divCreateChalEntry[0], { childList: true });
+}
+
+const addBadgeFormEntryEdit = async ($form) => {
+  const challengeId = window.location.pathname.split('/')[3];
+  const res = await getBadge(challengeId);
+  if (res === null) {
+    alert('Failed to get badge info');
+    return;
+  }
+  const badgeUrl = res.badge_url;
+
+  doAddBadgeForm($form, badgeUrl || '', async () => {
+    const newBadgeUrl = $('input[name="badge_url"]').val();
+    const res = await submitBadge(challengeId, newBadgeUrl, "PATCH");
+    if (res.status !== 200) {
+      console.error(`Failed to submit badge: ${res.status}`);
+      alert(`Failed to submit badge: ${res.status}`)
+    }
+  })
+}
+
+const hookChallengeEditPage = () => {
+  addBadgeFormEntryEdit($('#challenge-update-container'));
+}
+
+$(document).ready(() => {
+  if (window.location.pathname === '/admin/challenges/new') {
+    hookChallengeNewPage();
+  } else if (window.location.pathname.startsWith('/admin/challenges/')) {
+    const challengeId = window.location.pathname.split('/')[3];
+    if (challengeId.match(/^\d+$/)) {
+      hookChallengeEditPage();
+    }
+  }
+});

--- a/badge/__init__.py
+++ b/badge/__init__.py
@@ -1,0 +1,58 @@
+from flask import request
+from CTFd.models import db
+from CTFd.utils.plugins import register_admin_script
+from CTFd.plugins import register_plugin_assets_directory
+from CTFd.utils.decorators import admins_only
+from .model import Badges
+
+
+def onload(app):
+    register_plugin_assets_directory(app, base_path="/plugins/tsgctf/assets/")
+    register_admin_script("/plugins/tsgctf/assets/badge.js")
+
+
+def register_routes(app):
+    @app.route("/api/v1/challenges/<challenge>/badge", methods=["GET"])
+    def get_badge(challenge):
+        try:
+            challenge_i = int(challenge)
+        except ValueError:
+            return {"success": False, "errors": "Invalid challenge ID"}, 400
+        badge = Badges.query.filter_by(challenge=challenge_i).first_or_404()
+        return {"success": True, "badge_url": badge.url}
+
+    @app.route("/api/v1/challenges/<challenge>/badge", methods=["POST"])
+    @admins_only
+    def create_badge(challenge):
+        try:
+            challenge_i = int(challenge)
+        except ValueError:
+            return {"success": False, "errors": "Invalid challenge ID"}, 400
+        badge_url = request.get_json().get("badge_url")
+        badge_url = badge_url.split(" ")[0]
+        if len(badge_url) == 0:
+            badge_url = None
+
+        db.session.add(Badges(challenge_i, badge_url))
+        db.session.commit()
+        db.session.close()
+        return {"success": True}
+
+    @app.route("/api/v1/challenges/<challenge>/badge", methods=["PATCH"])
+    @admins_only
+    def patch_badge(challenge):
+        try:
+            challenge_i = int(challenge)
+        except ValueError:
+            return {"success": False, "errors": "Invalid challenge ID"}, 400
+        print(request.get_json())
+        badge_url = request.get_json().get("badge_url")
+        badge_url = badge_url.split(" ")[0]
+        if len(badge_url) == 0:
+            badge_url = None
+
+        badge = Badges.query.filter_by(challenge=challenge_i).first_or_404()
+        badge.url = badge_url
+        db.session.commit()
+        db.session.close()
+        return {"success": True}

--- a/badge/model.py
+++ b/badge/model.py
@@ -1,0 +1,14 @@
+from CTFd.models import db
+
+
+class Badges(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    challenge = db.Column(db.Integer, db.ForeignKey("challenges.id"), nullable=False)
+    url = db.Column(db.String(256), nullable=True)
+
+    def __init__(self, challenge, url):
+        self.challenge = challenge
+        self.url = url
+
+    def __repr__(self):
+        return "<Badge %r> (chall=%r)" % (self.id, self.challenge)


### PR DESCRIPTION
Add plugin `badge`.

- It creates new model `Badges` which is associated with `Challenges`.
- It creates a badge API:
  - GET    `/api/v1/challenges/<challenge>/badge`: Get a badge.
  - POST   `/api/v1/challenges/<challenge>/badge`: Create new badge. Admin only.
  - PATCH  `/api/v1/challenges/<challenge>/badge`: Modify existing badge. Admin only.
  - No DELETE method is provided.
- Add admin script and edit admin challenge view dynamically.
  - We want to keep CTFd repo as untouched as possible to make it easy to track upstream. The script is a little bit hacky but it's admin only.